### PR TITLE
Add support for username file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,25 @@ I must give thanks to [@martinwoodward](https://github.com/martinwoodward) becau
 
 ## Usage
 
+> **Note**
+> Processing username files assumes 1 username per line and will fail if any username is invalid.
+> This is because `gh-montage` is not retrieving usernames from GitHub API before processing them.
+
 ```shell
 $ gh montage --help
 
 Generate montage from GitHub user avatars.
 
 USAGE
-  gh-montage [options] <organization>
-  gh-montage [options] <organization>/<team>
+  gh montage [options] <organization>
+  gh montage [options] <organization>/<team>
+  gh montage [options] <path/to/username file>
 
 FLAGS
   -a, --avatar-pixels <integer>       Size of GitHub avatar icons in pixels; default '48'
   -d, --debug                         Enable debugging
   -f, --force                         Whether to overwrite output file if it exists
+  -h, --help                          Displays help usage
   -m, --montage-width <integer>       Width of GitHub montage in number of avatar icons; default '58'
   -o, --output-file <output-file>     Name of GitHub montage file to generate, without '.jpg' extension
   -p, --preserve                      Preserve temporary directory containing data

--- a/gh-montage
+++ b/gh-montage
@@ -8,18 +8,21 @@ ORGANIZATION=
 OUTPUTFILE=
 PRESERVE=false
 TEAM=
+USERS=()
 
 __USAGE="
 Generate montage from GitHub user avatars.
 
 USAGE
-  $(basename $0) [options] <organization>
-  $(basename $0) [options] <organization>/<team>
+  gh montage [options] <organization>
+  gh montage [options] <organization>/<team>
+  gh montage [options] <path/to/username file>
 
 FLAGS
   -a, --avatar-pixels <integer>       Size of GitHub avatar icons in pixels; default '$AVATARPIXELS'
   -d, --debug                         Enable debugging
   -f, --force                         Whether to overwrite output file if it exists
+  -h, --help                          Displays help usage
   -m, --montage-width <integer>       Width of GitHub montage in number of avatar icons; default '$MONTAGEWIDTH'
   -o, --output-file <output-file>     Name of GitHub montage file to generate, without '.png' extension
   -p, --preserve                      Preserve temporary directory containing data
@@ -92,6 +95,18 @@ elif [[ "$1" == *"/"* ]]; then
 	if [ -z "${OUTPUTFILE}" ]; then
 		OUTPUTFILE="$ORGANIZATION-$TEAM-$AVATARPIXELS.png"
 	fi
+elif [ -f "$1" ]; then
+	# If argument is valid file, read usernames from file
+	USERS_FILE="$1"
+	printf "Reading users from file: %s\n" "$USERS_FILE"
+
+	while IFS= read -r USER; do
+		USERS+=("$USER")
+	done < "$USERS_FILE"
+
+	if [ -z "${OUTPUTFILE}" ]; then
+		OUTPUTFILE="$(basename ""$USERS_FILE"").png"
+	fi
 else
 	ORGANIZATION="$1"
 
@@ -121,64 +136,62 @@ if ! $PRESERVE; then
 	trap 'rm -rf -- "$TMPDIR"' EXIT
 fi
 
-# Determine how many GitHub user
-if [ -z "${TEAM}" ]; then
-	QUERY='
-	query CountOrgAvatars($login: String!) {
-		organization(login: $login) {
-			membersWithRole {
-				totalCount
-			}
-		}
-	}'
+# Generate script around retrieving user avatars and generating montage as necessary
+echo "Generating GitHub montage script:  $TMPFILE"
 
-	JQ='.data.organization.membersWithRole.totalCount'
+if [ -n "${USERS}" ]; then
+	echo "GitHub avatars found:  ${#USERS[@]}"
+
+	for USER in "${USERS[@]}"; do	
+		QUERY='
+		query GetUser($login: String!) {
+			user(login: $login) {
+				avatarUrl
+				databaseId
+			}
+		}'
+
+		TEMPLATE="
+curl -s \"{{ .data.user.avatarUrl }}\" --output $TMPDIR/{{ .data.user.databaseId }}.jpg"
+
+		gh api graphql -f query="${QUERY}" -F login="$USER" --template="${TEMPLATE}" >> $TMPFILE
+	done
 else
-	QUERY='
-	query CountOrgTeamAvatars($login: String!, $slug: String!) {
-		organization(login: $login) {
-			team(slug: $slug) {
-				members {
+	if [ -z "${TEAM}" ]; then
+		QUERY='
+		query CountOrgAvatars($login: String!) {
+			organization(login: $login) {
+				membersWithRole {
 					totalCount
 				}
 			}
-		}
-	}'
+		}'
 
-	JQ='.data.organization.team.members.totalCount'
-fi
-
-AVATARCOUNT=$(gh api graphql -f query="${QUERY}" -F login="$ORGANIZATION" -F slug="$TEAM" --jq "$JQ")
-echo "GitHub avatars found:  $AVATARCOUNT"
-
-# Generate script commands to download GitHub user avatar images sized accordingly
-if [ -z "${TEAM}" ]; then
-	QUERY='
-	query GetOrgAvatars($login: String!, $endCursor: String) {
-		organization(login: $login) {
-			membersWithRole(first: 100, after: $endCursor) {
-				pageInfo {
-					endCursor
-					hasNextPage
-				}
-				nodes {
-					avatarUrl
-					databaseId
+		JQ='.data.organization.membersWithRole.totalCount'
+	else
+		QUERY='
+		query CountOrgTeamAvatars($login: String!, $slug: String!) {
+			organization(login: $login) {
+				team(slug: $slug) {
+					members {
+						totalCount
+					}
 				}
 			}
-		}
-	}'
+		}'
 
-	TEMPLATE="
-{{ range .data.organization.membersWithRole.nodes }}
-curl -s \"{{ .avatarUrl }}\" --output $TMPDIR/{{ .databaseId }}.jpg
-{{ end }}"
-else
-	QUERY='
-	query GetOrgTeamAvatars($login: String!, $slug: String!, $endCursor: String) {
-		organization(login: $login) {
-			team(slug: $slug) {
-				members(first: 100, after: $endCursor) {
+		JQ='.data.organization.team.members.totalCount'
+	fi
+
+	AVATARCOUNT=$(gh api graphql -f query="${QUERY}" -F login="$ORGANIZATION" -F slug="$TEAM" --jq "$JQ")
+	echo "GitHub avatars found:  $AVATARCOUNT"
+
+	# Generate script commands to download GitHub user avatar images sized accordingly
+	if [ -z "${TEAM}" ]; then
+		QUERY='
+		query GetOrgAvatars($login: String!, $endCursor: String) {
+			organization(login: $login) {
+				membersWithRole(first: 100, after: $endCursor) {
 					pageInfo {
 						endCursor
 						hasNextPage
@@ -189,17 +202,41 @@ else
 					}
 				}
 			}
-		}
-	}'
+		}'
 
-	TEMPLATE="
+		TEMPLATE="
+{{ range .data.organization.membersWithRole.nodes }}
+curl -s \"{{ .avatarUrl }}\" --output $TMPDIR/{{ .databaseId }}.jpg
+{{ end }}"
+
+	else
+		QUERY='
+		query GetOrgTeamAvatars($login: String!, $slug: String!, $endCursor: String) {
+			organization(login: $login) {
+				team(slug: $slug) {
+					members(first: 100, after: $endCursor) {
+						pageInfo {
+							endCursor
+							hasNextPage
+						}
+						nodes {
+							avatarUrl
+							databaseId
+						}
+					}
+				}
+			}
+		}'
+
+		TEMPLATE="
 {{ range .data.organization.team.members.nodes }}
 curl -s \"{{ .avatarUrl }}\" --output $TMPDIR/{{ .databaseId }}.jpg
 {{ end }}"
-fi
 
-echo "Generating GitHub montage script:  $TMPFILE"
-gh api graphql -f query="${QUERY}" -F login="$ORGANIZATION" -F slug="$TEAM" --paginate --template="${TEMPLATE}" >> $TMPFILE
+	fi
+
+	gh api graphql -f query="${QUERY}" -F login="$ORGANIZATION" -F slug="$TEAM" --paginate --template="${TEMPLATE}" >> $TMPFILE
+fi
 
 # Conclude script creation with commands to generate montage and execute
 cat << EOF >> $TMPFILE


### PR DESCRIPTION
This commit expands the variations of how we find users to use for the montage
to include a list of usernames. Because we are not retrieving these usernames
from the API ourself, the script will fail as soon as any invalid username is
encountered. Additionally, it will determine the montage image name based on
the input file provided, which can be overridden.
